### PR TITLE
Fix issue with db connection

### DIFF
--- a/ServerModules/docker-compose-postgres.yml
+++ b/ServerModules/docker-compose-postgres.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   postgres:
     container_name: postgres
-    image: postgres:9.6-alpine
+    image: postgres:9.6.16-alpine
     environment:
       - POSTGRES_DB="nakama"
     volumes:


### PR DESCRIPTION
It looks like the db image for postgres 9.6.17 no longer allows a blank db password, which causes the db startup to fail.

This specifies the version before the change, so that both the Postgres and Nakama containers start up successfully.